### PR TITLE
Refactor of the script and the example

### DIFF
--- a/multipage.py
+++ b/multipage.py
@@ -114,7 +114,7 @@ class MultiPage:
     def __initial_page_set(self) -> bool:
         return self.__initial_page is not None
 
-    def add_app(self, name: str, func: Callable()) -> None:
+    def add_app(self, name: str, func: Callable) -> None:
         new_app = App(name, func)
         self.__apps.append(new_app)
 

--- a/multipage.py
+++ b/multipage.py
@@ -12,11 +12,11 @@ cache = path / 'cache'
 cache_file = cache / "data.pkl"
 
 
-def change_page(page):
+def change_page(page: int) -> None:
     save({"current_page": page}, ["global"])
 
 
-def read_page():
+def read_page() -> int:
     data = load()["global"]
 
     if "current_page" in data:
@@ -26,11 +26,11 @@ def read_page():
 
 
 @st.cache(suppress_st_warning=True)
-def initialize(initial_page: int):
+def initialize(initial_page: int) -> None:
     change_page(initial_page)
 
 
-def save(variables: Dict[str, Any], namespaces: List[str]):
+def save(variables: Dict[str, Any], namespaces: List[str]) -> None:
     if not variables or not namespaces:
         return
 
@@ -47,19 +47,19 @@ def save(variables: Dict[str, Any], namespaces: List[str]):
 
     _save(data)
 
-def _save(data):
+def _save(data: Dict[str, Any]) -> None:
     cache.mkdir(parents=True, exist_ok=True)
     joblib.dump(data, cache_file)
 
 
-def load():
+def load() -> Dict[str, Any]:
     if not cache_file.exists():
         return defaultdict(dict)
     
     return joblib.load(cache_file)
 
 
-def clear_cache(variables=None, namespaces=None, all_variables=None):
+def clear_cache(variables: Dict[str, Any] = None, namespaces: List[str] = None, all_variables: bool = False) -> None:
     if variables and namespaces:
         data = load()
         for namespace in namespaces:
@@ -77,7 +77,7 @@ def clear_cache(variables=None, namespaces=None, all_variables=None):
 
 
 @st.cache(suppress_st_warning=True)
-def start_app():
+def start_app() -> None:
     clear_cache()
 
 
@@ -105,14 +105,14 @@ class MultiPage:
         self.__initial_page = App("__INITIALPAGE__", func)
     
     @property
-    def __initial_page_set(self):
+    def __initial_page_set(self) -> bool:
         return self.__initial_page is not None
 
-    def add_app(self, name: str, func):
+    def add_app(self, name: str, func: Callable()) -> None:
         new_app = App(name, func)
         self.__apps.append(new_app)
 
-    def run(self):
+    def run(self) -> None:
         initial_page = -1 if self.__initial_page_set else 0
         initialize(initial_page)
 

--- a/multipage.py
+++ b/multipage.py
@@ -8,7 +8,7 @@ import streamlit as st
 import joblib
 
 path = Path(__file__).resolve().parent
-cache = path / 'cache'
+cache = path / "cache"
 cache_file = cache / "data.pkl"
 
 
@@ -42,10 +42,11 @@ def save(variables: Dict[str, Any], namespaces: List[str]) -> None:
         if namespace in data:
             data[namespace].update(variables)
             continue
-        
+
         data[namespace] = variables
 
     _save(data)
+
 
 def _save(data: Dict[str, Any]) -> None:
     cache.mkdir(parents=True, exist_ok=True)
@@ -55,11 +56,15 @@ def _save(data: Dict[str, Any]) -> None:
 def load() -> Dict[str, Any]:
     if not cache_file.exists():
         return defaultdict(dict)
-    
+
     return joblib.load(cache_file)
 
 
-def clear_cache(variables: Dict[str, Any] = None, namespaces: List[str] = None, all_variables: bool = False) -> None:
+def clear_cache(
+    variables: Dict[str, Any] = None,
+    namespaces: List[str] = None,
+    all_variables: bool = False,
+) -> None:
     if variables and namespaces:
         data = load()
         for namespace in namespaces:
@@ -69,7 +74,7 @@ def clear_cache(variables: Dict[str, Any] = None, namespaces: List[str] = None, 
                     continue
 
                 del data[namespace][variable]
-        
+
         _save(data)
 
     if all_variables:
@@ -85,6 +90,7 @@ def start_app() -> None:
 class App:
     name: str
     func: Callable
+
 
 @dataclass
 class MultiPage:
@@ -103,7 +109,7 @@ class MultiPage:
     @initial_page.setter
     def initial_page(self, func: Callable) -> None:
         self.__initial_page = App("__INITIALPAGE__", func)
-    
+
     @property
     def __initial_page_set(self) -> bool:
         return self.__initial_page is not None
@@ -146,8 +152,11 @@ class MultiPage:
                     page = min(len(self.__apps) - 1, page + 1)
                     change_page(page)
 
-            st.sidebar.markdown(f"""<h1 style="text-align:center;">{self.navbar_name}</h1>""", unsafe_allow_html=True)
-            st.sidebar.text('\n')
+            st.sidebar.markdown(
+                f"""<h1 style="text-align:center;">{self.navbar_name}</h1>""",
+                unsafe_allow_html=True,
+            )
+            st.sidebar.text("\n")
 
             for i in range(len(self.__apps)):
                 if st.sidebar.button(self.__apps[i].name):

--- a/multipage.py
+++ b/multipage.py
@@ -1,165 +1,161 @@
+import json
+from collections import defaultdict
+from dataclasses import dataclass, field
+from typing import List, Callable, Any, Dict
+from pathlib import Path
+
 import streamlit as st
-import os
 import joblib
 
-path = os.getcwd()
-cache = os.path.join(path, 'cache')
+path = Path(__file__).resolve().parent
+cache = path / 'cache'
+cache_file = cache / "data.pkl"
 
-def change_page(pag):
-	with open(os.path.join(cache, 'cache.txt'), "w") as f:
-		f.truncate()
-		f.write(f"{pag}")
-		f.close()
+
+def change_page(page):
+    save({"current_page": page}, ["global"])
+
 
 def read_page():
-	with open(os.path.join(cache, 'cache.txt'), "r") as f:
-		pag = f.readline()
-		pag = int(pag)
-		f.close()
-	return pag
+    data = load()["global"]
+
+    if "current_page" in data:
+        return int(data["current_page"])
+
+    return 0
+
 
 @st.cache(suppress_st_warning=True)
-def initialize(initial_page_test=False):
-	if initial_page_test:
-		toWrite= -1
-	else:
-		toWrite= 0
-	try:
-		change_page(toWrite)
-	except FileNotFoundError:
-		os.mkdir(cache)
-		change_page(toWrite)
-
-def save(var_list, name, page_names):
-	try:
-		dic = joblib.load(os.path.join(cache, 'dic.pkl'))
-	except FileNotFoundError:
-		dic = {}
-
-	for app in page_names:
-		if app in list(dic.keys()):
-			if name not in dic[app]:
-				dic[app] += [name]
-		else:
-			dic[app] = [name]
+def initialize(initial_page: int):
+    change_page(initial_page)
 
 
-	joblib.dump(var_list, os.path.join(cache, name + '.pkl'))
-	joblib.dump(dic, os.path.join(cache, 'dic.pkl'))
+def save(variables: Dict[str, Any], namespaces: List[str]):
+    if not variables or not namespaces:
+        return
 
-	return os.path.join(cache, name + '.pkl')
+    data = load()
 
-def load(name):
-	try:
-		return joblib.load(os.path.join(cache, name + '.pkl'))
-	except FileNotFoundError:
-		return ''
+    new_data = {namespace: variables for namespace in namespaces}
 
-def clear_cache(filenames=None):
-	if filenames:
-		for element in filenames:
-			os.remove(os.path.join(cache, element + '.pkl'))
-	else:
-		filelist = [file for file in os.listdir(cache) if file.endswith(".pkl")]
-		for file in filelist:
-			os.remove(os.path.join(cache, file))
+    for namespace, variables in new_data.items():
+        if namespace in data:
+            data[namespace].update(variables)
+            continue
+        
+        data[namespace] = variables
+
+    _save(data)
+
+def _save(data):
+    cache.mkdir(parents=True, exist_ok=True)
+    joblib.dump(data, cache_file)
+
+
+def load():
+    if not cache_file.exists():
+        return defaultdict(dict)
+    
+    return joblib.load(cache_file)
+
+
+def clear_cache(variables=None, namespaces=None, all_variables=None):
+    if variables and namespaces:
+        data = load()
+        for namespace in namespaces:
+            for variable in variables:
+                print(variable, namespace)
+                if variable not in data[namespace]:
+                    continue
+
+                del data[namespace][variable]
+        
+        _save(data)
+
+    if all_variables:
+        cache_file.unlink(missing_ok=True)
+
 
 @st.cache(suppress_st_warning=True)
 def start_app():
-	try:
-		clear_cache()
-	except:
-		pass
-
-class app:
-	def __init__(self, name, func):
-		self.name = name
-		self.func = func
+    clear_cache()
 
 
+@dataclass
+class App:
+    name: str
+    func: Callable
+
+@dataclass
 class MultiPage:
-	def __init__(self, next_page="Next Page", previous_page="Previous Page", navbar_name="Navigation", start_button="Let's go!"):
-		self.__initial_page = None
-		self.start_button = start_button
-		self.__initial_page_set = False
-		self.__apps = []
-		self.navbar_name = navbar_name
-		self.__block_navbar = False
-		self.next_page_button = next_page
-		self.previous_page_button = previous_page
+    __initial_page: App = None
+    __apps: List[App] = field(default_factory=list)
 
-	def disable_navbar(self):
-		self.__block_navbar = True
+    start_button: str = "Let's go!"
+    navbar_name: str = "Navigation"
+    next_page_button: str = "Next Page"
+    previous_page_button: str = "Previous Page"
 
-	def set_initial_page(self, func):
-		self.__initial_page = app("__INITIALPAGE__", func)
-		self.__initial_page_set = True
+    @property
+    def initial_page(self) -> App:
+        return self.__initial_page
 
+    @initial_page.setter
+    def initial_page(self, func: Callable) -> None:
+        self.__initial_page = App("__INITIALPAGE__", func)
+    
+    @property
+    def __initial_page_set(self):
+        return self.__initial_page is not None
 
-	def add_app(self, name, func):
-		new_app = app(name, func)
-		self.__apps.append(new_app)
+    def add_app(self, name: str, func):
+        new_app = App(name, func)
+        self.__apps.append(new_app)
 
-	def run(self):
-		initialize(self.__initial_page_set)
+    def run(self):
+        initial_page = -1 if self.__initial_page_set else 0
+        initialize(initial_page)
 
-		pag = read_page()
+        page = read_page()
 
-		container_1 = st.beta_container()
+        container_1 = st.container()
 
-		if pag == -1:
-			container_2 = st.beta_container()
-			placeholder = st.empty()
-			with container_2:
-				if placeholder.button(self.start_button):
-					pag = 0
-					change_page(pag)
-					placeholder.empty()
-		with container_1:
-			if pag==-1:
-				self.__initial_page.func()
+        if page == -1:
+            container_2 = st.container()
+            placeholder = st.empty()
+            with container_2:
+                if placeholder.button(self.start_button):
+                    page = 0
+                    change_page(page)
+                    placeholder.empty()
 
-			else:
-				side_1, side_2 = st.sidebar.beta_columns(2)
+        with container_1:
+            if page == -1:
+                self.__initial_page.func()
+                return
 
-				with side_1:
-					if st.button(self.previous_page_button):
-						if pag > 0:
-							pag -= 1 
-						else:
-							pag = 0
+            side_1, side_2 = st.sidebar.columns(2)
 
-						change_page(pag)
+            with side_1:
+                if st.button(self.previous_page_button):
+                    page = max(0, page - 1)
+                    change_page(page)
 
+            with side_2:
+                if st.button(self.next_page_button):
+                    page = min(len(self.__apps) - 1, page + 1)
+                    change_page(page)
 
-				with side_2:
-					if st.button(self.next_page_button):
-						if pag < len(self.__apps)-1:
-							pag +=1
-						else:
-							pag = len(self.__apps)-1 
+            st.sidebar.markdown(f"""<h1 style="text-align:center;">{self.navbar_name}</h1>""", unsafe_allow_html=True)
+            st.sidebar.text('\n')
 
-						change_page(pag)
+            for i in range(len(self.__apps)):
+                if st.sidebar.button(self.__apps[i].name):
+                    page = i
+                    change_page(page)
 
+            data = load()
 
+            print(data)
 
-				st.sidebar.markdown(f"""<h1 style="text-align:center;">{self.navbar_name}</h1>""", unsafe_allow_html=True)
-				st.sidebar.text('\n')
-
-
-				for i in range(len(self.__apps)):
-					if st.sidebar.button(self.__apps[i].name):
-						pag = i
-						change_page(pag)
-
-				try:
-					prev_vars = []
-					dic = joblib.load(os.path.join(cache, 'dic.pkl'))
-					for appname in dic[self.__apps[pag].name]:
-						prev_vars += load(os.path.join(cache, appname))
-					if len(prev_vars) == 1:
-						prev_vars = prev_vars[0]
-				except:
-					prev_vars = None
-
-				self.__apps[pag].func(prev_vars)
+            self.__apps[page].func(**data)

--- a/multipage_example.py
+++ b/multipage_example.py
@@ -1,17 +1,8 @@
 import streamlit as st
 from multipage import save, MultiPage, start_app, clear_cache
 
-start_app() #Clears the cache when the app is started
-
-app = MultiPage()
-app.start_button = "Let's go!"
-app.navbar_name = "Navigation"
-app.next_page_button = "Next Page"
-app.previous_page_button = "Previous Page"
-
-
 def startpage():
-	st.markdown("""# streamlit-multipage-framework
+    st.markdown("""# streamlit-multipage-framework
 Framework for implementing multipage structure in streamlit apps.
 It was inspired by upraneelnihar's project: https://github.com/upraneelnihar/streamlit-multiapps.
 
@@ -59,72 +50,93 @@ Developed by: Yan Almeida.
 9. Use the `run` method.""")
 
 
-def app1(prev_vars): #First page
-	if prev_vars != None:
+def app1(**prev_vars):
+    variables = prev_vars.get("App1", {})
 
-		start_index = prev_vars  #Defines the start index for a selectbox (defined below) as the option previously chosen by the user
-	else:
-		start_index = 1 #Defines the start index for a selectbox (defined below) as 1
+    if not (variables and "start_index" in variables):
+        variables["start_index"] = 0
 
-	st.button("Do nothing...")
-	var1 = 10
-	var2 = 5
-	if st.button("Click here to save the variables..."):
-		st.write("First number: " + str(var1))
-		st.write('Second number: ' + str(var2))
-		save(var_list=[var1, var2], name="App1", page_names=["App2", "App3"]) #Saves the variables to be used on the second and third pages.
-		######
+    start_index = variables["start_index"]
 
-	#Shows how to set placeholders based on a selection
-	new_var_list = ["This framework rocks!", "This framework is really cool!", "I really liked this framework!"]
-	new_var = st.selectbox("Select an option: ", new_var_list, index=start_index) #Creates a selectbox in order to show how to keep the option chosen by the user even after he leaves the page...
-	start_index = new_var_list.index(new_var)
+    st.button("Do nothing...")
 
-	save([start_index], "placeholder1", ["App2", "App3"]) #Saves the variable "start_index" to be used again on the first page
+    var1 = 10
+    var2 = 5
 
-def app2(prev_vars): #Second page
-	if type(prev_vars) is int: #Checks if the user saved the variables previously
-		st.write("Ooops... You forgot to save the variables...")
-		start_index = prev_vars
-		save([start_index], "placeholder", ["App1"])
+    if st.button("Click here to save the variables..."):
+        st.write("First number: " + str(var1))
+        st.write('Second number: ' + str(var2))
+        save({"var1":var1, "var2":var2}, ["App2", "App3"])
 
-	else:
-		start_index, var1, var2 = prev_vars #Reads the variables previously saved
-		if st.button("Click here to sum the variables"):
-			sum_var = var1+var2
-			st.write(sum_var)
-			
-		if st.button("Click here to save a new variable"):
-			var3 = 27
-			st.write(var3)
-			save(var_list=[var3], name="last_var", page_names=["App3"])
-		save([start_index], "placeholder", ["App1"])
+    new_var_list = ["This framework rocks!", "This framework is really cool!", "I really liked this framework!"]
+    new_var = st.selectbox("Select an option: ", new_var_list, index=start_index)
+    start_index = new_var_list.index(new_var)
+
+    save({"start_index": start_index}, ["App1"])
 
 
+def app2(**prev_vars):
+    
+    if not prev_vars:
+        st.write("Ooops... You forgot to save the variables...")
+        return
 
-		#####
+    variables = prev_vars.get("App2", {})
+    required_variables = ["var1", "var2"]
+    if any(variable not in variables for variable in required_variables):
+        st.write("Missing one of the required variables")
+        st.write(prev_vars)
+        return
 
-def app3(prev_vars): #Third page
-	if type(prev_vars) is int: #Checks if the user saved the variables previously
-		st.write("Ooops... You forgot to save the variables...")
-		start_index = prev_vars
-		save([start_index], "placeholder", ["App1"])
-	else:
-		try: #Checks if the user saved the last variable on the second page
-			start_index, var1, var2, var3 = prev_vars
-			if st.button("Click here to erase the last variable"):
-				clear_cache(["last_var"]) #Erases the variables saved under the name "last_var"
+    var1 = variables["var1"]
+    var2 = variables["var2"]
 
-			if st.button("Click here to multiply the variables"):
-				st.write(var1*var2*var3)
-			save([start_index], "placeholder", ["App1"])
-		except:
-			st.write("Ooops... You forgot to save the last variable...")
-			start_index = prev_vars[0]
-			save([start_index], "placeholder", ["App1"])
+    if st.button("Click here to sum the variables"):
+        sum_var = var1 + var2
+        st.write(sum_var)
+        
+    if st.button("Click here to save a new variable"):
+        var3 = 27
+        st.write(var3)
+        save({"var3": var3}, ["App3"])
 
-app.set_initial_page(startpage)
-app.add_app("App1", app1) #Adds first page (app1) to the framework
-app.add_app("App2", app2) #Adds second page (app2) to the framework
-app.add_app("App3", app3) #Adds third page (app3) to the framework
-app.run() #Runs the multipage app!
+
+def app3(**prev_vars):
+    if not prev_vars:
+        st.write("Ooops... You forgot to save the variables...")
+        start_index = prev_vars
+        save({"placeholder": start_index}, ["App1"])
+        
+        return
+
+    variables = prev_vars.get("App3", {})
+    required_variables = ["var1", "var2", "var3"]
+    if any(variable not in variables for variable in required_variables):
+        st.write("Missing one of the required variables")
+        st.write(prev_vars)
+        return
+
+    var1 = variables["var1"]
+    var2 = variables["var2"]
+    var3 = variables["var3"]
+    
+    if st.button("Click here to erase the last variable"):
+        clear_cache(["var3"], ["App3"])
+
+    if st.button("Click here to multiply the variables"):
+        st.write(var1*var2*var3)
+
+
+start_app()
+
+app = MultiPage()
+app.initial_page = startpage
+app.start_button = "Let's go!"
+app.navbar_name = "Navigation"
+app.next_page_button = "Next Page"
+app.previous_page_button = "Previous Page"
+
+app.add_app("App1", app1)
+app.add_app("App2", app2)
+app.add_app("App3", app3)
+app.run()

--- a/multipage_example.py
+++ b/multipage_example.py
@@ -1,6 +1,7 @@
 import streamlit as st
 from multipage import save, MultiPage, start_app, clear_cache
 
+
 def startpage():
     st.markdown("""# streamlit-multipage-framework
 Framework for implementing multipage structure in streamlit apps.
@@ -65,10 +66,14 @@ def app1(**prev_vars):
 
     if st.button("Click here to save the variables..."):
         st.write("First number: " + str(var1))
-        st.write('Second number: ' + str(var2))
-        save({"var1":var1, "var2":var2}, ["App2", "App3"])
+        st.write("Second number: " + str(var2))
+        save({"var1": var1, "var2": var2}, ["App2", "App3"])
 
-    new_var_list = ["This framework rocks!", "This framework is really cool!", "I really liked this framework!"]
+    new_var_list = [
+        "This framework rocks!",
+        "This framework is really cool!",
+        "I really liked this framework!",
+    ]
     new_var = st.selectbox("Select an option: ", new_var_list, index=start_index)
     start_index = new_var_list.index(new_var)
 
@@ -76,7 +81,7 @@ def app1(**prev_vars):
 
 
 def app2(**prev_vars):
-    
+
     if not prev_vars:
         st.write("Ooops... You forgot to save the variables...")
         return
@@ -94,7 +99,7 @@ def app2(**prev_vars):
     if st.button("Click here to sum the variables"):
         sum_var = var1 + var2
         st.write(sum_var)
-        
+
     if st.button("Click here to save a new variable"):
         var3 = 27
         st.write(var3)
@@ -106,7 +111,7 @@ def app3(**prev_vars):
         st.write("Ooops... You forgot to save the variables...")
         start_index = prev_vars
         save({"placeholder": start_index}, ["App1"])
-        
+
         return
 
     variables = prev_vars.get("App3", {})
@@ -119,12 +124,12 @@ def app3(**prev_vars):
     var1 = variables["var1"]
     var2 = variables["var2"]
     var3 = variables["var3"]
-    
+
     if st.button("Click here to erase the last variable"):
         clear_cache(["var3"], ["App3"])
 
     if st.button("Click here to multiply the variables"):
-        st.write(var1*var2*var3)
+        st.write(var1 * var2 * var3)
 
 
 start_app()


### PR DESCRIPTION
This is a refactor, functionality is kept the same.

Some of the changes:

- Reduce duplicated code
- Use one global cache file for all pages, dividing into namespaces
- Use dataclasses instead of classic classes
- Standardize the format of the `prev_variables` to be a dict
- Remove all try/except logic and replace them with Python idioms
- Replace os.path with the pathlib module
- Add Black Formatting
- Add Type Hints
- Remove unnecessary comments